### PR TITLE
Mismatch between ENV in README vs Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN apk add bluez
 
 ENV BLE_ADDRESS="" \
     BLE_PASSWORD="" \
-	UNIT="" \
+    UNIT="" \
     MQTT_BROKER="" \
     MQTT_PORT="1883" \
-    MQTT_USERNAME="" \
+    MQTT_USER="" \
     MQTT_PASSWORD="" \
     LOGGING_LEVEL="INFO"
 
@@ -17,4 +17,4 @@ WORKDIR /app
 
 RUN pip install -r requirements.txt
 
-CMD ["sh", "-c", "python main.py --address ${BLE_ADDRESS} --password ${BLE_PASSWORD} --unit ${UNIT} --mqtt --mqtt_broker ${MQTT_BROKER} --mqtt_port ${MQTT_PORT} --mqtt_user ${MQTT_USERNAME} --mqtt_password ${MQTT_PASSWORD} --logging_level ${LOGGING_LEVEL}"]
+CMD ["sh", "-c", "python main.py --address ${BLE_ADDRESS} --password ${BLE_PASSWORD} --unit ${UNIT} --mqtt --mqtt_broker ${MQTT_BROKER} --mqtt_port ${MQTT_PORT} --mqtt_user ${MQTT_USER} --mqtt_password ${MQTT_PASSWORD} --logging_level ${LOGGING_LEVEL}"]


### PR DESCRIPTION
Readme was using `MQTT_USER` and the original script also uses `mqtt_user` so I thought editing the Dockerfile was the best place to change this.