### PR TITLE
docker: add ability to reload a sys module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
 FROM python:3-alpine
 
-RUN apk add bluez
-
 ENV BLE_ADDRESS="" \
     BLE_PASSWORD="" \
-    UNIT="" \
+    UNIT="W" \
+    MQTT_ENABLED="true" \
     MQTT_BROKER="" \
     MQTT_PORT="1883" \
     MQTT_USER="" \
     MQTT_PASSWORD="" \
-    LOGGING_LEVEL="INFO"
+    LOGGING_LEVEL="INFO" \
+    SYS_MODULE_TO_RELOAD=""
 
 ADD . /app
 
 WORKDIR /app
 
-RUN pip install -r requirements.txt
+RUN apk add --no-cache bluez && pip install -r requirements.txt
 
-CMD ["sh", "-c", "python main.py --address ${BLE_ADDRESS} --password ${BLE_PASSWORD} --unit ${UNIT} --mqtt --mqtt_broker ${MQTT_BROKER} --mqtt_port ${MQTT_PORT} --mqtt_user ${MQTT_USER} --mqtt_password ${MQTT_PASSWORD} --logging_level ${LOGGING_LEVEL}"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # evseMQTT
-`evseMQTT` is a Python library designed for communicating with EVSE-based Electric Vehicle Charging Wallboxes using Bluetooth Low Energy (BLE), and exposing its data and controls to Home Assistant using MQTT Discovery. Due to potential security concerns of WiFi connectivity, this library facilitates a local, no cloud connection to your EVSE device. It has been tested on the Besen BS20 model using a Raspberry Pi Zero 2 W.
+
+`evseMQTT` is a Python library designed for communicating with EVSE-based Electric Vehicle Charging Wallboxes using Bluetooth Low Energy (BLE), and exposing its data and controls to Home Assistant using MQTT Discovery.
+Due to potential security concerns of WiFi connectivity, this library facilitates a local, no cloud connection to your EVSE device. It has been tested on the Besen BS20 model using a Raspberry Pi Zero 2 W.
 
 The code base is by no means perfect or especially beautiful -- pragmatic hacks are applied where needed.
 ![Home Assistant Device view](https://raw.githubusercontent.com/slespersen/evseMQTT/refs/heads/main/evseMQTT_home_assistant.png)
+
 ## Features
 
 `evseMQTT` provides the following functionalities:
@@ -17,6 +20,7 @@ The code base is by no means perfect or especially beautiful -- pragmatic hacks 
 - **Automatic Reconnect**: In case the Bluetooth connection is stale, and no message has been received for more than 35 seconds, the script will automatically reinitialize.
 
 Additionally, `evseMQTT` allows you to read:
+
 - **Current Consumption of Energy:** Monitor the energy consumption in kilowatt-hours (kWh).
 - **Errors**: Monitor potential errors.
 - **Phase characteristics**: Monitor voltage and amperage across the phases present on the charger.
@@ -83,7 +87,7 @@ python main.py --address "your_device_mac_address" \
 ```
 
 ### Run as container
-   
+
 ```bash
 
 docker run -d --name evseMQTT \
@@ -92,6 +96,7 @@ docker run -d --name evseMQTT \
       -e BLE_ADDRESS="your_device_mac_address" \
       -e BLE_PASSWORD="your_6_digit_pin" \
       -e UNIT="kW" \
+      -e MQTT_ENABLED="true" \
       -e MQTT_BROKER="your_mqtt_broker_address" \
       -e MQTT_PORT=1883 \
       -e MQTT_USER="your_mqtt_username" \
@@ -99,6 +104,17 @@ docker run -d --name evseMQTT \
       -e LOGGING_LEVEL="INFO" \
       ghcr.io/slespersen/evsemqtt:latest
 ```
+
+### handle bluetooth module crashes in container
+
+in some cases the bluetooth module crashes and needs to be restarted,
+this can be handled by adding the following arguments to the docker run command:
+
+- `-cap-add=SYS_MODULE`
+- `-v /lib/modules:/lib/modules:ro`
+- `-e SYS_MODULE_TO_RELOAD="btusb"`
+
+for usb bluetooth dongles use `btusb`, on a Raspberry Pi use `hci_uart`
 
 ### Determine BLE address for your EVSE
 
@@ -109,6 +125,7 @@ bluetoothctl scan le
 ```
 
 results in something like this:
+
 ```plain
 Discovery started
 [CHG] Controller B8:27:EB:B4:51:EB Discovering: yes
@@ -116,7 +133,9 @@ Discovery started
 ```
 
 ## Caveats
+
 This library is in no means complete, when compared to the original app - some features missing:
+
 - Charging History
 - LCD Brightness
 - Password Reset
@@ -124,21 +143,22 @@ This library is in no means complete, when compared to the original app - some f
 - WiFi setup
 
 Seemingly unexpected behavior, but working as intended:
+
 - When changing the device name, the device will disconnect and the script will wait for 35 seconds, since the last received message, before reconnecting.
 
 ## Acknowledgements
 
 A big thank you to the following contributors:
 
--   [bakkers](https://github.com/bakkers) for documenting findings: https://gist.github.com/bakkerrs/cb75e3c3a337f8f38a3f84f4b49beaa5
-    
--   [johnwoo-nl](https://github.com/johnwoo-nl) for building emproto: https://github.com/johnwoo-nl/emproto/tree/main?tab=readme-ov-file
-    
--   [Phil242](https://github.com/Phil242), [FlorentVTT](https://github.com/FlorentVTT), and [DutchDevelop](https://github.com/DutchDevelop) for their original efforts in decoding the EVSE protocol
+- [bakkers](https://github.com/bakkers) for documenting findings: https://gist.github.com/bakkerrs/cb75e3c3a337f8f38a3f84f4b49beaa5
+
+- [johnwoo-nl](https://github.com/johnwoo-nl) for building emproto: https://github.com/johnwoo-nl/emproto/tree/main?tab=readme-ov-file
+
+- [Phil242](https://github.com/Phil242), [FlorentVTT](https://github.com/FlorentVTT), and [DutchDevelop](https://github.com/DutchDevelop) for their original efforts in decoding the EVSE protocol
 
 ## Tested Devices
 
--   **Besen BS20:** This library has been tested and verified to work with the Besen BS20 Electric Vehicle Charging Wallbox.
+- **Besen BS20:** This library has been tested and verified to work with the Besen BS20 Electric Vehicle Charging Wallbox.
 
 ## License
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+MQTT_ENABLED=${MQTT_ENABLED:-"true"}
+MQTT_ARGS=""
+SYS_MODULE_TO_RELOAD=${SYS_MODULE_TO_RELOAD:-""}
+
+if [ "${MQTT_ENABLED}" = "true" ]; then
+    MQTT_ARGS="--mqtt --mqtt_broker ${MQTT_BROKER} --mqtt_port ${MQTT_PORT} --mqtt_user ${MQTT_USER} --mqtt_password ${MQTT_PASSWORD}"
+fi
+
+if [ -n "${SYS_MODULE_TO_RELOAD}" ]; then
+    echo "sys module reload enabled for: ${SYS_MODULE_TO_RELOAD}"
+    if [ -d /lib/modules/ ]; then
+      echo "reload module: ${SYS_MODULE_TO_RELOAD}"
+      modprobe -r "${SYS_MODULE_TO_RELOAD}"
+      sleep 2
+      modprobe "${SYS_MODULE_TO_RELOAD}"
+      sleep 2
+      echo "sys module reload done"
+    else
+      echo "modules folder '/lib/modules/' not mounted. skip reload."
+    fi
+fi
+
+echo "Starting evseMQTT ..."
+
+python main.py ${MQTT_ARGS} \
+      --address "${BLE_ADDRESS}" \
+      --password "${BLE_PASSWORD}" \
+      --unit "${UNIT}" \
+      --logging_level "${LOGGING_LEVEL}"


### PR DESCRIPTION
relates to #7 

the output in the docker container looks like this


```
    
sys module reload enabled for: btusb
reload module: btusb
sys module reload done
Starting evseMQTT ...
2024-12-11 11:06:49,186 - evseMQTT - INFO - Scanning for evse BLE devices...
2024-12-11 11:06:49,187 - evseMQTT - INFO - Connected to MQTT broker
2024-12-11 11:06:54,286 - evseMQTT - INFO - Found device: ACP#Chargy (9C:A5:0E:C8:A2:12)
2024-12-11 11:06:54,286 - evseMQTT - INFO - Connecting...
2024-12-11 11:06:54,286 - evseMQTT - INFO - Connecting to 9C:A5:0E:C8:A2:12, attempt 1
2024-12-11 11:06:55,136 - evseMQTT - INFO - Connected to 9C:A5:0E:C8:A2:12
2024-12-11 11:06:55,136 - evseMQTT - INFO - Starting notifications for 0000fff1-0000-1000-8000-00805f9b34fb on 9C:A5:0E:C8:A2:12
2024-12-11 11:06:55,205 - evseMQTT - INFO - Notifications started for 0000fff1-0000-1000-8000-00805f9b34fb on 9C:A5:0E:C8:A2:12
2024-12-11 11:06:55,206 - evseMQTT - INFO - Connected.
2024-12-11 11:06:55,206 - evseMQTT - INFO - Waiting for device initialization...
2024-12-11 11:06:55,206 - evseMQTT - INFO - Device not initialized yet, waiting...
2024-12-11 11:06:55,350 - evseMQTT - INFO - Received command 4
2024-12-11 11:06:55,350 - evseMQTT - INFO - Device sent a single charge ac status

``